### PR TITLE
Replaced Add Builder to Add Step in step 3

### DIFF
--- a/AppDev/ATP-OKE/LabGuide650BuildDocker.md
+++ b/AppDev/ATP-OKE/LabGuide650BuildDocker.md
@@ -120,7 +120,7 @@ Open your project in Developer Cloud, and follow the steps below:
 
     ![](images/650/im52.png)
 
-- From the **Add Builder** drop-down, select **Docker Builder->Docker push**. 
+- Using the **Add Step** drop-down, select **Docker Builder->Docker push**. 
   - Your **Registry Host** and **Image Name** should be pre-filled with the previously specified values.
 
   ![](images/650/im46-1.png)


### PR DESCRIPTION
In step 3 the Docker Push step was still referred to be in Add Builder drop down, but on current UI it is Add Step drop down.