### PR TITLE
Secure endpoint

### DIFF
--- a/AppDev/helidon-k8s/Kubernetes/base-kubernetes/KubernetesBaseLabs.md
+++ b/AppDev/helidon-k8s/Kubernetes/base-kubernetes/KubernetesBaseLabs.md
@@ -749,9 +749,9 @@ Note that it is possible to match multiple paths in the same ingress, and they c
 
 ---
 
-<details><summary><b>Allowing http access ?</b></summary>
+<details><summary><b>How to block http access ?</b></summary>
 <p>
-We have provided a certificate in a secret to use for https traffic, but the ingress controller will not block http traffic without some ingress controller specific annotations that seem to very betwene not only the different ingress controllers but also the same controller in different cloud providers. 
+We have provided a certificate in a secret to use for https traffic, but the ingress controller will not block http traffic without some ingress controller specific annotations that seem to very between not only the different ingress controllers but also the same controller in different cloud providers. 
 
 One simple solution however is to modify the load balancer settings to block non ssl traffic. This is generally cloud provider specific however.
 </p></details>
@@ -835,25 +835,25 @@ We now have a working endpoint, let's try accessing it using curl - expect an er
 -  `curl -i -k -X GET https://<ip address>/sf`
 
 ```
-HTTP/1.1 503 Service Temporarily Unavailable
-Server: openresty/1.15.8.2
-Date: Fri, 27 Dec 2019 18:59:48 GMT
-Content-Type: text/html
-Content-Length: 203
-Connection: keep-alive
+HTTP/2 503 
+server: nginx/1.17.8
+date: Fri, 27 Mar 2020 09:20:42 GMT
+content-type: text/html
+content-length: 197
+strict-transport-security: max-age=15724800; includeSubDomains
 
 <html>
 <head><title>503 Service Temporarily Unavailable</title></head>
 <body>
 <center><h1>503 Service Temporarily Unavailable</h1></center>
-<hr><center>openresty/1.15.8.2</center>
+<hr><center>nginx/1.17.8</center>
 </body>
 </html>
 ```
 
 <details><summary><b>What's with the *-k* flag ?</b></summary>
 <p>
-Previously we didn't use the -k flag or https when testing in the Helidon labs. That's because in the development phase we were using a direct http connection. Now we're using https (because that's what you should do in a production environment) we need to tell curl not to generate a error because in this case we're using a self signed certificate 
+Previously we didn't use the -k flag or https when testing in the Helidon labs. That's because in the development phase we were using a direct http connection and connecting to a service running locally, and the micro-service itself didn't use https. Now we're using the ingress controller to provide us with a secure https connection (because that's what you should do in a production environment) we need to tell curl not to generate a error because in this case we're using a self signed certificate 
 </p></details>
 
 We got a **service unavailable** error. This is because that web page is recognised as an ingress rule, but there are no pods able to deliver the service. This isn't a surprise as we haven't started them yet !
@@ -863,12 +863,12 @@ If we tried to go to a URL that's not defined we will as expected get a **404 er
 -  `curl -i -k -m -X GET https://<ip address>/unknowningress`
 
 ```
-HTTP/1.1 404 Not Found
-Server: openresty/1.15.8.2
-Date: Fri, 27 Dec 2019 19:03:52 GMT
-Content-Type: text/plain; charset=utf-8
-Content-Length: 21
-Connection: keep-alive
+HTTP/2 404 
+server: nginx/1.17.8
+date: Fri, 27 Mar 2020 09:22:24 GMT
+content-type: text/plain; charset=utf-8
+content-length: 21
+strict-transport-security: max-age=15724800; includeSubDomains
 
 default backend - 404
 ```
@@ -1408,12 +1408,12 @@ The External_IP column displays the external address.
   -  `curl -i -k -X GET -u jack:password https://132.145.232.69/store/stocklevel`
 
 ```
-HTTP/1.1 200 OK
-Server: openresty/1.15.8.2
-Date: Sun, 29 Dec 2019 18:05:24 GMT
-Content-Type: application/json
-Content-Length: 184
-Connection: keep-alive
+HTTP/2 200 
+server: nginx/1.17.8
+date: Fri, 27 Mar 2020 09:19:00 GMT
+content-type: application/json
+content-length: 185
+strict-transport-security: max-age=15724800; includeSubDomains
 
 [{"itemCount":4980,"itemName":"rivet"},{"itemCount":4,"itemName":"chair"},{"itemCount":981,"itemName":"door"},{"itemCount":25,"itemName":"window"},{"itemCount":20,"itemName":"handle"}]
 ```
@@ -1485,12 +1485,12 @@ Of course the other services are also available, for example we can get the mini
   -  `curl -i -k -X GET https://132.145.232.69/sf/minimumChange`
 
 ```
-HTTP/1.1 200 OK
-Server: openresty/1.15.8.2
-Date: Sun, 29 Dec 2019 18:33:15 GMT
-Content-Type: text/plain
-Content-Length: 1
-Connection: keep-alive
+HTTP/2 200 
+server: nginx/1.17.8
+date: Fri, 27 Mar 2020 09:56:25 GMT
+content-type: text/plain
+content-length: 1
+strict-transport-security: max-age=15724800; includeSubDomains
 
 3
 ```
@@ -1500,12 +1500,12 @@ And in this case we are going to look at data on the admin port for the stock ma
 - Readiness call: `curl -i -k -X GET https://132.145.232.69/smmgt/health/ready`
 
 ```
-HTTP/1.1 200 OK
-Server: openresty/1.15.8.2
-Date: Sun, 29 Dec 2019 18:34:40 GMT
-Content-Type: application/json
-Content-Length: 164
-Connection: keep-alive
+HTTP/2 200 
+server: nginx/1.17.8
+date: Fri, 27 Mar 2020 09:56:57 GMT
+content-type: application/json
+content-length: 166
+strict-transport-security: max-age=15724800; includeSubDomains
 
 {"outcome":"UP","status":"UP","checks":[{"name":"stockmanager-ready","state":"UP","status":"UP","data":{"department":"TestOrg","persistanceUnit":"HelidonATPJTA"}}]}
 ```
@@ -1517,12 +1517,12 @@ We saw in the helidon labs that it's possible to have the helidon framework moni
   -  `curl -i -k -X GET https://132.145.232.69/sf/status`
 
 ```
-HTTP/1.1 200 OK
-Server: openresty/1.15.8.2
-Date: Sun, 29 Dec 2019 18:32:50 GMT
-Content-Type: application/json
-Content-Length: 49
-Connection: keep-alive
+HTTP/2 200 
+server: nginx/1.17.8
+date: Fri, 27 Mar 2020 09:57:31 GMT
+content-type: application/json
+content-length: 51
+strict-transport-security: max-age=15724800; includeSubDomains
 
 {"name":"My Shop","alive":true,"frozen":false}
 ```
@@ -1606,12 +1606,12 @@ If we now get the status resource data again it's also updated
 - Query the status: `curl -i -k -X GET https://132.145.232.69/sf/status`
 
 ```bash
-HTTP/1.1 200 OK
-Server: openresty/1.15.8.2
-Date: Sun, 29 Dec 2019 21:24:26 GMT
-Content-Type: application/json
-Content-Length: 48
-Connection: keep-alive
+HTTP/2 200 
+server: nginx/1.17.8
+date: Fri, 27 Mar 2020 09:57:31 GMT
+content-type: application/json
+content-length: 51
+strict-transport-security: max-age=15724800; includeSubDomains
 
 {"name":"Tims Shop","alive":true,"frozen":false}
 ```
@@ -1620,9 +1620,13 @@ We've shown how to change the config in helidon using config maps, but the same 
 
 
 
+### Thoughts on security
 
+This lab has only implemented basic security in that it's securing the REST API using the Ingress controller.
 
+There are other ways of securing the connection however, we've put together a [short document](SecuringTheRestEngpoint.md) on some of the other appriaches.
 
+Also when deploying in Kubernetes you should create roles and users for performing specific functions. The [Kubernetes documentation](https://kubernetes.io/docs/concepts/security/overview/) has more information on it's security.
 
 
 

--- a/AppDev/helidon-k8s/Kubernetes/base-kubernetes/KubernetesBaseLabs.md
+++ b/AppDev/helidon-k8s/Kubernetes/base-kubernetes/KubernetesBaseLabs.md
@@ -651,7 +651,31 @@ For the moment there are no actual ingress rules defined yet, we can see this us
 No resources found in tg-helidon namespace.
 ```
 
+As we will be providing a secure TLS protected connection we need to create a certificate to protect the connection. In a **production** environment this would be accomplished by going to a certificate authority and having them issue a certificate. This however can take time as certificates are (usually) based on a DNS name and a commercial provider may well require that you prove your organizations identity before issuing a certificate.
 
+To enable the lab to complete in a reasonable time we will therefore be generating our own self-signed certificate. For a lab environment that's fine, but in a production environment you wouldn't do this.
+
+- Run the following command to generate a certificate.
+
+  - `openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout tls.key -out tls.crt -subj "/CN=nginxsvc/O=nginxsvc"`
+
+```
+Generating a 2048 bit RSA private key
+............................+++
+............................................................................................+++
+writing new private key to 'tls.key'
+-----
+```
+ 
+The certificate needs to be in a Kubernetes secret, we'll look at these in more detail, but for now :
+
+- Run the following command to save the certificate as a secret
+
+  - `kubectl create secret tls tls-secret --key tls.key --cert tls.crt`
+ 
+```
+secret/tls-secret created
+```
 
 <details><summary><b>More on Ingress rules</b></summary>
 <p>
@@ -662,7 +686,7 @@ The rules define URL's and service endpoints to pass those URLs to, the URL's ca
 
 An ingress rule defines a URL path that is looked for, when it's discovered the action part of the rule is triggered and that 
 
-There are ***many*** possible tupes of rules that we could define, but here we're just going to look at two types: Rules that are plain in that the recognize part of a path, and just pass the whole URL along to the actual service, and rules that re-write the URL before passing it on. Let's look at the simpler case first, that of the forwarding.
+There are ***many*** possible types of rules that we could define, but here we're just going to look at two types: Rules that are plain in that the recognize part of a path, and just pass the whole URL along to the actual service, and rules that re-write the URL before passing it on. Let's look at the simpler case first, that of the forwarding.
 
 ```
 apiVersion: extensions/v1beta1
@@ -673,6 +697,8 @@ metadata:
     # use the shared ingress-nginx
     kubernetes.io/ingress.class: "nginx"
 spec:
+  tls:
+  - secretName: tls-secret
   rules:
   - http:
       paths:
@@ -686,7 +712,7 @@ Firstly note that the api here is the extensions/v1beta1 API. In more recent ver
 
 The metadata specifies the name of the ingress (in this case zipkin) and also the annotations. Annotations are a way of specifying name / value pairs that can be monitored for my other services. In this case we are specifying that this ingress Ingress rule has a label of kubernetes.io/ingress.class and a value of nginx. The nginx ingress controller will have setup a request inthe Kubernetes infrastructure so it will detect any ingress rules with that annotation as being targeted to be processed by it. This allows us to define rules as standalonw items, without having to setup and define a configuration for each rule in the ingress controller configuration itself. This annotation based approach is a simple way for services written to be cloud native to identify other kubernetes objects and determine how to hendle them, as we will see when we look at monitoring in kubenteres.
 
-The spec section basically defined the rules to do the processing, basically if there's an http connection coming in with a url that starts with /zipkin then the connection will be proxied to the zikin service on port 9411. The entire URL will be forwarded including the /zipkin.
+The spec section basically defined the certificate for the TLS connection and the rules to do the processing, basically if there's an connection coming in with a url that starts with /zipkin then the connection will be proxied to the zikin service on port 9411. The entire URL will be forwarded including the /zipkin.
 
 In some cases we don't want the entire URL to be forwarded however, what if we were using the initial part of the URL to identify a different service, perhaps for the health or metrics capabilities of the microservices which are on a different port (http://storefront:9081/health for example) In this case we want to re-write the incomming URL as it's passed to the target
 
@@ -699,6 +725,8 @@ metadata:
     # use a re-writer
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
+  tls:
+  - secretName: tls-secret
   rules:
   - http:
       paths:
@@ -721,6 +749,15 @@ Note that it is possible to match multiple paths in the same ingress, and they c
 
 ---
 
+<details><summary><b>Allowing http access ?</b></summary>
+<p>
+We have provided a certificate in a secret to use for https traffic, but the ingress controller will not block http traffic without some ingress controller specific annotations that seem to very betwene not only the different ingress controllers but also the same controller in different cloud providers. 
+
+One simple solution however is to modify the load balancer settings to block non ssl traffic. This is generally cloud provider specific however.
+</p></details>
+
+---
+
 
 
 - Apply the Ingress Config file : 
@@ -734,6 +771,7 @@ ingress.extensions/storefront-status created
 ingress.extensions/stockmanager-status created
 ingress.extensions/stockmanager-management created
 ingress.extensions/storefront-management created
+ingress.extensions/storefront-openapi created
 ```
 
 We can see the resulting ingresses using kubectl
@@ -770,6 +808,8 @@ Direct mappings
 
 `/smmgt/<stuff> -> stockmanager:9081/<stuff> e.g. /smmgt/metrics -> stockmanager:8081/metrics`
 
+`/openapi -> storefront:8080/openapi`
+
 Notice the different ports in use on the target.
 
 Visualize the port the ingress controller is running on :
@@ -792,7 +832,7 @@ Or look up the ingress service in the namespace *'default'* in the dashboard, th
 
 We now have a working endpoint, let's try accessing it using curl - expect an error !
 
--  `curl -i -X GET http://<ip address>/sf`
+-  `curl -i -k -X GET https://<ip address>/sf`
 
 ```
 HTTP/1.1 503 Service Temporarily Unavailable
@@ -811,11 +851,16 @@ Connection: keep-alive
 </html>
 ```
 
+<details><summary><b>What's with the *-k* flag ?</b></summary>
+<p>
+Previously we didn't use the -k flag or https when testing in the Helidon labs. That's because in the development phase we were using a direct http connection. Now we're using https (because that's what you should do in a production environment) we need to tell curl not to generate a error because in this case we're using a self signed certificate 
+</p></details>
+
 We got a **service unavailable** error. This is because that web page is recognised as an ingress rule, but there are no pods able to deliver the service. This isn't a surprise as we haven't started them yet !
 
 If we tried to go to a URL that's not defined we will as expected get a **404 error**:
 
--  `curl -i -X GET http://<ip address>/unknowningress`
+-  `curl -i -k -m -X GET https://<ip address>/unknowningress`
 
 ```
 HTTP/1.1 404 Not Found
@@ -1360,7 +1405,7 @@ kubernetes                                    ClusterIP      10.96.0.1       <no
 The External_IP column displays the external address. 
 
 - Let's try to get some data - **you might get an error**
-  -  `curl -i -X GET -u jack:password http://132.145.232.69:80/store/stocklevel`
+  -  `curl -i -k -X GET -u jack:password https://132.145.232.69/store/stocklevel`
 
 ```
 HTTP/1.1 200 OK
@@ -1437,7 +1482,7 @@ As we are runnig zipkin and have an ingress setup to let us access the zipkin po
 Of course the other services are also available, for example we can get the minimum change using the re-writer rules
 
 - Consult minimum change
-  -  `curl -i -X GET http://132.145.232.69:80/sf/minimumChange`
+  -  `curl -i -k -X GET https://132.145.232.69/sf/minimumChange`
 
 ```
 HTTP/1.1 200 OK
@@ -1452,7 +1497,7 @@ Connection: keep-alive
 
 And in this case we are going to look at data on the admin port for the stock management service and get it's readiness data
 
-- Readiness call: `curl -i -X GET http://132.145.232.69:80/smmgt/health/ready`
+- Readiness call: `curl -i -k -X GET https://132.145.232.69/smmgt/health/ready`
 
 ```
 HTTP/1.1 200 OK
@@ -1469,7 +1514,7 @@ Connection: keep-alive
 We saw in the helidon labs that it's possible to have the helidon framework monitor the configuration files and triger a refresh of the configuration data if something changed. Let's see how that works in Kubernetes.
 
 - Get the status resource data :
-  -  `curl -i -X GET http://132.145.232.69:80/sf/status`
+  -  `curl -i -k -X GET https://132.145.232.69/sf/status`
 
 ```
 HTTP/1.1 200 OK
@@ -1558,7 +1603,7 @@ The storefront-config.yaml file has now changed to reflect the modifications you
 
 If we now get the status resource data again it's also updated
 
-- Query the status: `curl -i -X GET http://132.145.232.69:80/sf/status`
+- Query the status: `curl -i -k -X GET https://132.145.232.69/sf/status`
 
 ```bash
 HTTP/1.1 200 OK
@@ -1570,7 +1615,7 @@ Connection: keep-alive
 
 {"name":"Tims Shop","alive":true,"frozen":false}
 ```
-Of course there is time delay from the change being visible in the pod to the Helidon framework doing it's scan to detect the change and reloading the config, so yu may have to issue the curl command a few times to see when the change has fully propogated.
+Of course there is time delay from the change being visible in the pod to the Helidon framework doing it's scan to detect the change and reloading the config, so you may have to issue the curl command a few times to see when the change has fully propogated.
 We've shown how to change the config in helidon using config maps, but the same principle woudl apply if you were using secrets and modified those (though there isn't really a usable secret editor in the dashboard)
 
 

--- a/AppDev/helidon-k8s/Kubernetes/base-kubernetes/SecuringTheRestEndpoint.md
+++ b/AppDev/helidon-k8s/Kubernetes/base-kubernetes/SecuringTheRestEndpoint.md
@@ -1,0 +1,67 @@
+[Go to Overview Page](../Kubernetes-labs.md)
+
+![](../../../../common/images/customer.logo2.png)
+
+# Migration of Monolith to Cloud Native
+
+## Should I secure my REST API ?
+
+Stupid question ! 
+
+The answer is that of course you should. Even if the information you have is public and you are not charging for access to your service you should still protect it against malicious actors who want to use it as a way to break into your systems, or vandals who just to deny access to others.
+
+## Securing the REST API
+
+This module looks at **some** of the ways you can secure your REST API's. Just to be clear, this is not a complete list and there are other approaches not covered here, but I have attempted to cover the major approaches.
+
+## What security approach to use ?
+
+There is no right or wrong way to secure your REST API's the best solution is to do a team assessment of the risks you have. You need to to a team assessment because as individuals it's very easy to get wrapped up in your own specific security experiences and viewpoints and not look at other areas, for example my background is such that when writing this document I was focusing on TLS and authentication / authorization and had to be reminded about SQL injection attacks, even though they are quite common attack.
+
+Below are some thoughts, but these need to be considered with professional advice and in the context of your specific situation.
+
+### In your service itself
+
+You can of course have your micro-service itself implement the end point termination and other security features. In the Helidon part of the lab you will have seen how Helidon can implement authentication to limit who can access certain features of the micro-service.
+
+You could of course implement a TLS end point in your application as well, but then you have to implement your own certificate management. By taking the encryption all the way to the micro-service you'd also be limiting what you can do in terms of a Layer 7 firewall where you use an external service to inspect your data, for example to rate limit for specific endpoints, or dynamically add capabilities such as SQL Injection protection.
+
+Taking the encryption all the way to the micro-service does however reduce the chance that you will be subject to a attack by compromised network infrastructure (with modern clouds this is unlikely as the vendor can almost certainly do a better job at managing their infrastructure and detecting attacks than most end user organizations who will have a different focus.)
+
+Taking encryption to the service also means that you are responsible for ensuring that your service meets the latest patches and updates. It mag be great to have the fine grained control, but with that comes the responsibility of monitoring the encryption libraries you've used for vulnerabilities and patching them to keep up to the latest versions. On that subject you should **never** write your own encryption unless you are an genuine expert, professionals are guaranteed to do a better job at that than you, and it's incredibly easily to make a mistake with encryption. 
+
+### Using the Ingress controller
+
+This is the approach we have taken in the labs, we use the ingress controller to perform the encryption of the https connections from outside the Kubernetes cluster, and then internal to the cluster pass the information on to the micro-service unencrypted. The benefit of this is your service no longer needs to manage the encryption, though the ingress controller doesn't operate functions such as authentication and authorization. 
+
+### In the load Balancer
+
+Load Balancers are generally in two types. 
+
+The ones that operate on a TCP/IP connection don't look inside the contents of the packet, they just send the packet on to the specified destination and port. They block all other communication except that on the in-bound port they are configured to work on, so they are also an in-bound firewall restricting the traffic into your network.
+
+The other type operates at the http / https level. These can perform operations such as terminating the SSL connection, potentially adding extra headers to the http request (for example with proxy information) and usually they can also then re-encrypt the http(s) traffic as it makes the onward connection to the micro-service if you want internal encryption. This type of load balancer may have dedicated hardware to perform functions such as encryption / decryption of data, and is likely to have better certificate management than you would implement in your own micro-service code.
+
+The second type can provide an https connection externaly but internally route the requests to your micro-service (usually via an ingress controller) so you don;t need to implement the encryption in the ingress controller or micro-service.
+
+Load balancers however are often not part of your Kubernetes environment, and often are offered as a distinct service from the micro-service environment and used by other services from your cloud provider. This means that they may well have their own certificate management approaches and not integrate into the Kubernetes based certificate systems.
+
+### With an API Gateway
+
+Technologies such as an API gateway are applied (usually with their own load balancer) to examine the REST API Requests and to externally apply policy to those requests, this is done on the edge of your environment and prevents out of policy REST API calls even reaching your micro-service. For example an API Gateway would typically be configured with policies that ensure that the correct authentication details are applied to the connection, often also validating the supplied details are correct. Other typical functions are ensuring that the data is in the correct format, potentially applying checks against SQL Injection, and performing functions such as rate lmiting and API key management (for example limiting access only to applications form organizations that have been issued with an access key.
+
+## Internal to the cluster data encryption
+
+Most Kubernetes implementations can run a service mesh like Istio (other service mesh implementations are of course available.) These cam provide man capabilities, but they usually offer mechanisms whereby you can encrypt internal communications within the cluster.
+
+If you are operating a distributed Kubernetes cluster where the microservices are spread around with physical separation  between the nodes, then this may be a good aprpoach to ensuring that a wide area communications provider (or someone that's hacked into them) cannot access the data (though usually wide area links woudl have their own encryption applied to protect the actuall connection.)
+
+## Certificate management
+
+Managing certificates can be a pain, especially if you have short lived certificates. To make this easier you can use a tool that will automaticaly source, renew and manage certificates.
+
+ **For certificates held in Kubernetes** there is a service called [CertManager](https://cert-manager.io/docs/) This service will source and maintain cetficicates for you, a typical use case may be to specify in the Ingress rule that a certificate is needed, along with information of the type of certificate, issuing authority etc. The certmanager will then get a certificate and place it in the appropriate Kubernetes secret. The certificate will then be used as if it was manually installed.
+ 
+# Where to get security assistance.
+
+This section has only covered at a simple level a few of the security options. Clearly in a sensitive commercial situation you will want to conduct a thorough security assessment of your risks, ensure you have not made any common security mistakes etc. Oracle (and I'm sure other vendors and consultants) has a security assessment service that can help with this.

--- a/AppDev/helidon-k8s/Kubernetes/cloud-native-labs/Health-readiness-liveness/Health-liveness-readiness.md
+++ b/AppDev/helidon-k8s/Kubernetes/cloud-native-labs/Health-readiness-liveness/Health-liveness-readiness.md
@@ -19,8 +19,8 @@ These labs look at how that is achieved.
 
 As we've seen a service in Kubernetes is delivered by programs running in containers. The way a container operates is that it runs a single program, once that program exists then the container exits, and the pod is no longer providing the service. 
 
-- Make sure that the service is running. 
-  - In a terminal type : `curl -i -X GET -u jack:password http://localhost:80/store/stocklevel`
+- Make sure that the service is running (replace the IP address with the one for your service)  
+  - In a terminal type : `curl -i -k -X GET -u jack:password https://987.123.456.789/store/stocklevel`
 
 ```
 HTTP/1.1 200 OK
@@ -71,9 +71,9 @@ root@storefront-65bd698bb4-cq26l:/# command terminated with exit code 137
 
 Within a second or two of the process being killed the connection to the container in the pod is terminated as the container exits.
 
-If we now try getting the data again it still responds:
+If we now try getting the data again it still responds  (replace the IP address with the one for your service)
 
-- `curl -i -X GET -u jack:password http://localhost:80/store/stocklevel`
+- `curl -i -k -X GET -u jack:password https://987.123.456.789/store/stocklevel`
 
 ```
 HTTP/1.1 200 OK
@@ -452,7 +452,7 @@ The ReadinessProbe section should now look like this :
 
 The various options for readiness are similar to those for Liveliness, except you see here we've got an exec instead of httpGet.
 
-The exec means that we are going to run code **inside** the pod to determine if the pod is ready to serve requests. The command section defined the command that will be run and the arguments. In this case we run the /bin/bash shell, -c means to use the arguments as a command (so it won't try and be interactive) and the 'curl -s http://localhost:9080/health/ready | json_pp | grep "\"outcome\" : \"UP\""' is the command.
+The exec means that we are going to run code **inside** the pod to determine if the pod is ready to serve requests. The command section defined the command that will be run and the arguments. In this case we run the /bin/bash shell, -c means to use the arguments as a command (so it won't try and be interactive) and the `'curl -s http://localhost:9080/health/ready | json_pp | grep "\"outcome\" : \"UP\""'` is the command.
 
 Some points about 'curl -s http://localhost:9080/health/ready | json_pp | grep "\"outcome\" : \"UP\""'
 
@@ -658,8 +658,8 @@ What happens if a request is made to the service while before the pod is ready ?
 
 To see what happens if the readiness probe does not work we can simply undeploy the stock manager service.
 
-- First let's check it's running fine 
-  -  `curl -i -X GET -u jack:password http://your-ip:80/store/stocklevel
+- First let's check it's running fine  (replace the IP address with the one for your service)
+  -  `curl -i -k -X GET -u jack:password https://987.123.456.789/store/stocklevel
 
 ```
 HTTP/1.1 200 OK
@@ -712,8 +712,8 @@ replicaset.apps/zipkin-88c48d8b9       1         1         1       28m
 ```
 Something else has also happened though, the storefront service has no pods in the ready state, neither does the storefront deployment and replica set. The readiness probe has run against the storefront pod and when the probe checked the results it found that the storefront pod was not in a position to operate, because the service it depended on (the stock manager) was no longer available. 
 
-- Let's try accessing the service
-  -  `curl -i -X GET -u jack:password http://your-ip:80/store/stocklevel`
+- Let's try accessing the service (replace the IP address with the one for your service)
+  -  `curl -i -k -X GET -u jack:password https://987.123.456.789/store/stocklevel`
 
 ```
 HTTP/1.1 503 Service Temporarily Unavailable
@@ -792,9 +792,9 @@ replicaset.apps/storefront-74cd999d8      1         1         1       35m
 replicaset.apps/zipkin-88c48d8b9          1         1         1       35m
 ```
 
-The storefront readiness probe has kicked in and the services are all back in the ready state once again
+The storefront readiness probe has kicked in and the services are all back in the ready state once again  (replace the IP address with the one for your service)
 
-- Check the service : `curl -i -X GET -u jack:password http://your-ip:80/store/stocklevel`
+- Check the service : `curl -i -k -X GET -u jack:password https://987.123.456.789/store/stocklevel`
 
 ```
 HTTP/1.1 200 OK

--- a/AppDev/helidon-k8s/Kubernetes/cloud-native-labs/Health-readiness-liveness/Health-liveness-readiness.md
+++ b/AppDev/helidon-k8s/Kubernetes/cloud-native-labs/Health-readiness-liveness/Health-liveness-readiness.md
@@ -76,12 +76,12 @@ If we now try getting the data again it still responds  (replace the IP address 
 - `curl -i -k -X GET -u jack:password https://987.123.456.789/store/stocklevel`
 
 ```
-HTTP/1.1 200 OK
-Server: openresty/1.15.8.2
-Date: Thu, 02 Jan 2020 14:10:04 GMT
-Content-Type: application/json
-Content-Length: 184
-Connection: keep-alive
+HTTP/2 200 
+server: nginx/1.17.8
+date: Fri, 27 Mar 2020 10:08:15 GMT
+content-type: application/json
+content-length: 220
+strict-transport-security: max-age=15724800; includeSubDomains
 
 [{"itemCount":4980,"itemName":"rivet"},{"itemCount":4,"itemName":"chair"},{"itemCount":981,"itemName":"door"},{"itemCount":25,"itemName":"window"},{"itemCount":20,"itemName":"handle"}]
 ```
@@ -458,7 +458,7 @@ Some points about 'curl -s http://localhost:9080/health/ready | json_pp | grep "
 
 Firstly this is a command string that actually runs 3 commands connecting the output of one to the input of the other. If you exec to the pod you can actually run these by hand if you like
 
-The first (the curl) gets the readiness data from the service (you may remember this in the Helidon labs) 
+The first (the curl) gets the readiness data from the service (you may remember this in the Helidon labs) In this case as the code is running within the pod itself, so it's a localhost connection and as it'd direct to the micro-service it's http
 
 ```
 root@storefront-b44457b4d-29jr7:/# curl -s http://localhost:9080/health/ready 

--- a/AppDev/helidon-k8s/Kubernetes/cloud-native-labs/Rolling-updates/Rolling-updates.md
+++ b/AppDev/helidon-k8s/Kubernetes/cloud-native-labs/Rolling-updates/Rolling-updates.md
@@ -431,10 +431,10 @@ Events:
 
 We see the usual deployment info, the Image is indeed the new one we specified, `fra.ocir.io/oractdemeabdmnative/tg_repo/storefront:0.0.2` and the events log section shows us the various stages of rolling out the update.
 
-We should of course check that out update is correctly delivering a service
+We should of course check that our update is correctly delivering a service (replace the IP address with one for your service)
 
 ```
-$ curl -i -X GET -u jack:password http://localhost:80/store/stocklevel
+$ curl -i -k -X GET -u jack:password https://987.123.456.789/store/stocklevel
 HTTP/1.1 200 OK
 Server: openresty/1.15.8.2
 Date: Fri, 03 Jan 2020 12:56:24 GMT
@@ -444,8 +444,8 @@ Connection: keep-alive
 
 [{"itemCount":4980,"itemName":"rivet"},{"itemCount":4,"itemName":"chair"},{"itemCount":981,"itemName":"door"},{"itemCount":25,"itemName":"window"},{"itemCount":20,"itemName":"handle"}]
 ```
-- Now let's check the output form the StausResource:
-  -  `curl -i -X GET http://my-ip:80/sf/status`
+- Now let's check the output from the StausResource (again replace the IP address with the one for your service) :
+  -  `curl -i -k -X GET https://987.123.456.789/sf/status`
 
 ```
 HTTP/1.1 200 OK
@@ -642,8 +642,8 @@ replicaset.apps/zipkin-88c48d8b9                                         1      
 ```
 We see that all of the pods are not the origional replica set version, and there are no pods in the new one.
 
-- If we check this by going to the status we can see the rollback has worked :
-  -  `curl -i -X GET http://my-ip:80/sf/status`
+- If we check this by going to the status we can see the rollback has worked (remember to replace the IP address with the one for your service) :
+  -  `curl -i -k -X GET https://987.123.456.789/sf/status`
 
 ```
 HTTP/1.1 200 OK

--- a/AppDev/helidon-k8s/Kubernetes/cloud-native-labs/Rolling-updates/Rolling-updates.md
+++ b/AppDev/helidon-k8s/Kubernetes/cloud-native-labs/Rolling-updates/Rolling-updates.md
@@ -435,12 +435,12 @@ We should of course check that our update is correctly delivering a service (rep
 
 ```
 $ curl -i -k -X GET -u jack:password https://987.123.456.789/store/stocklevel
-HTTP/1.1 200 OK
-Server: openresty/1.15.8.2
-Date: Fri, 03 Jan 2020 12:56:24 GMT
-Content-Type: application/json
-Content-Length: 184
-Connection: keep-alive
+HTTP/2 200 
+server: nginx/1.17.8
+date: Fri, 27 Mar 2020 10:33:47 GMT
+content-type: application/json
+content-length: 220
+strict-transport-security: max-age=15724800; includeSubDomains
 
 [{"itemCount":4980,"itemName":"rivet"},{"itemCount":4,"itemName":"chair"},{"itemCount":981,"itemName":"door"},{"itemCount":25,"itemName":"window"},{"itemCount":20,"itemName":"handle"}]
 ```
@@ -448,12 +448,12 @@ Connection: keep-alive
   -  `curl -i -k -X GET https://987.123.456.789/sf/status`
 
 ```
-HTTP/1.1 200 OK
-Server: openresty/1.15.8.2
-Date: Fri, 03 Jan 2020 12:56:15 GMT
-Content-Type: application/json
-Content-Length: 49
-Connection: keep-alive
+HTTP/2 200 
+server: nginx/1.17.8
+date: Fri, 27 Mar 2020 10:34:05 GMT
+content-type: application/json
+content-length: 51
+strict-transport-security: max-age=15724800; includeSubDomains
 
 {"name":"My Shop","alive":true,"version":"0.0.2"}
 ```
@@ -646,12 +646,12 @@ We see that all of the pods are not the origional replica set version, and there
   -  `curl -i -k -X GET https://987.123.456.789/sf/status`
 
 ```
-HTTP/1.1 200 OK
-Server: openresty/1.15.8.2
-Date: Fri, 03 Jan 2020 13:08:54 GMT
-Content-Type: application/json
-Content-Length: 31
-Connection: keep-alive
+HTTP/2 200 
+server: nginx/1.17.8
+date: Fri, 27 Mar 2020 10:34:43 GMT
+content-type: application/json
+content-length: 51
+strict-transport-security: max-age=15724800; includeSubDomains
 
 {"name":"My Shop","alive":true,"version":"0.0.2"}
 ```

--- a/AppDev/helidon-k8s/Kubernetes/monitoring-kubernetes/MonitoringWithPrometheusLab.md
+++ b/AppDev/helidon-k8s/Kubernetes/monitoring-kubernetes/MonitoringWithPrometheusLab.md
@@ -393,7 +393,7 @@ If we look at the data we can see that the retrieved value is 0 (it may be anoth
 Let's make a few calls to list the stock and see what we get
 
 - Execute the following command a few times, **replacing *your_ip* with your Ingress endpoint:**
-  -  `curl -i -X GET -u jack:password http://your_ip:80/store/stocklevel`
+  -  `curl -i -k -X GET -u jack:password https://your_ip/store/stocklevel`
 
 ```
 HTTP/1.1 200 OK

--- a/AppDev/helidon-k8s/Kubernetes/monitoring-kubernetes/MonitoringWithPrometheusLab.md
+++ b/AppDev/helidon-k8s/Kubernetes/monitoring-kubernetes/MonitoringWithPrometheusLab.md
@@ -269,7 +269,7 @@ Be ***very*** careful to only remove the # character and **no other whitespace**
 ```
 
 - Now run the script **undeploy.sh** to remove the deployments
-  -  `./undeploy.sh`
+  -  `bash undeploy.sh`
 
 ``` 
 Deleting storefront deployment
@@ -297,7 +297,7 @@ replicaset.apps/zipkin-88c48d8b9         1         1         1       8h
 This script just does a kubectl delete -f on each of the deployments. 
 
 - Now recreate the deployments: 
-  -  `./deploy.sh `
+  -  `bash deploy.sh `
 
 ```
 Creating zipkin deployment
@@ -396,12 +396,12 @@ Let's make a few calls to list the stock and see what we get
   -  `curl -i -k -X GET -u jack:password https://your_ip/store/stocklevel`
 
 ```
-HTTP/1.1 200 OK
-Server: openresty/1.15.8.2
-Date: Mon, 30 Dec 2019 16:58:26 GMT
-Content-Type: application/json
-Content-Length: 184
-Connection: keep-alive
+HTTP/2 200 
+server: nginx/1.17.8
+date: Fri, 27 Mar 2020 10:05:52 GMT
+content-type: application/json
+content-length: 220
+strict-transport-security: max-age=15724800; includeSubDomains
 
 [{"itemCount":4980,"itemName":"rivet"},{"itemCount":4,"itemName":"chair"},{"itemCount":981,"itemName":"door"},{"itemCount":25,"itemName":"window"},{"itemCount":20,"itemName":"handle"}]
 ```

--- a/AppDev/helidon-k8s/Kubernetes/monitoring-kubernetes/VisualizingWithGrafanaLab.md
+++ b/AppDev/helidon-k8s/Kubernetes/monitoring-kubernetes/VisualizingWithGrafanaLab.md
@@ -130,12 +130,12 @@ Now any pod that provides the `application:list_all_stock_meter_one_min_rate_per
   -  `curl -i -k -X GET -u jack:password https://123.456.789.123/store/stocklevel`
 
 ```
-HTTP/1.1 200 OK
-Server: openresty/1.15.8.2
-Date: Tue, 31 Dec 2019 15:37:01 GMT
-Content-Type: application/json
-Content-Length: 184
-Connection: keep-alive
+HTTP/2 200 
+server: nginx/1.17.8
+date: Fri, 27 Mar 2020 10:06:39 GMT
+content-type: application/json
+content-length: 220
+strict-transport-security: max-age=15724800; includeSubDomains
 
 [{"itemCount":4980,"itemName":"rivet"},{"itemCount":4,"itemName":"chair"},{"itemCount":981,"itemName":"door"},{"itemCount":25,"itemName":"window"},{"itemCount":20,"itemName":"handle"}]
 ```
@@ -278,15 +278,15 @@ Lastly we need to rename out panel, after all "New dashboard" is not especially 
 - Using the duration dropdown in the upper right ![grafana-duration-dropdown-6-hours](images/grafana-duration-dropdown-6-hours.png) change the duration to be the last 5 mins ![grafana-duration-dropdown-5-mins](images/grafana-duration-dropdown-5-mins.png)
 
 - Now make a bunch of curl requests to get some new data (replacing the IP address with the one for your service of course)
-  -  `curl -i -k -X GET -u jack:password https://localhost/store/stocklevel`
+  -  `curl -i -k -X GET -u jack:password https://987.123.456.789/store/stocklevel`
 
 ```
-HTTP/1.1 200 OK
-Server: openresty/1.15.8.2
-Date: Tue, 31 Dec 2019 18:03:39 GMT
-Content-Type: application/json
-Content-Length: 184
-Connection: keep-alive
+HTTP/2 200 
+server: nginx/1.17.8
+date: Fri, 27 Mar 2020 10:08:15 GMT
+content-type: application/json
+content-length: 220
+strict-transport-security: max-age=15724800; includeSubDomains
 
 [{"itemCount":4980,"itemName":"rivet"},{"itemCount":4,"itemName":"chair"},{"itemCount":981,"itemName":"door"},{"itemCount":25,"itemName":"window"},{"itemCount":20,"itemName":"handle"}]
 ```

--- a/AppDev/helidon-k8s/Kubernetes/monitoring-kubernetes/VisualizingWithGrafanaLab.md
+++ b/AppDev/helidon-k8s/Kubernetes/monitoring-kubernetes/VisualizingWithGrafanaLab.md
@@ -126,8 +126,8 @@ Grafana allows us to combine the data using the Prometheus query language, by us
 
 Now any pod that provides the `application:list_all_stock_meter_one_min_rate_per_second` data will be part of the total, giving us the total rate across all of the pods.
 
-- Make a few requests using curl to generate some new data
-  -  `curl -i -X GET -u jack:password http://localhost:80/store/stocklevel`
+- Make a few requests using curl to generate some new data (replace the ip address with the one for your service)
+  -  `curl -i -k -X GET -u jack:password https://123.456.789.123/store/stocklevel`
 
 ```
 HTTP/1.1 200 OK
@@ -277,8 +277,8 @@ Lastly we need to rename out panel, after all "New dashboard" is not especially 
 
 - Using the duration dropdown in the upper right ![grafana-duration-dropdown-6-hours](images/grafana-duration-dropdown-6-hours.png) change the duration to be the last 5 mins ![grafana-duration-dropdown-5-mins](images/grafana-duration-dropdown-5-mins.png)
 
-- Now make a bunch of curl requests to get some new data
-  -  `curl -i -X GET -u jack:password http://localhost:80/store/stocklevel`
+- Now make a bunch of curl requests to get some new data (replacing the IP address with the one for your service of course)
+  -  `curl -i -k -X GET -u jack:password https://localhost/store/stocklevel`
 
 ```
 HTTP/1.1 200 OK


### PR DESCRIPTION
Updated with the TLS connections. Changes made to creating a certificate and setting up the TLS secret using the certificate, updating the ingress rules to use the secret, updating all the curl requests to use the -k and https connections (also removing the :80 on the port) and updating the example output to reflect the https headers coming from the ingress controller vs the http headers that previously came from the helidon web server.
I've tested all of the curl calls and they seem to work fine
Related to this (in the orahub projects) I've updated the scripts to generate load and test data