### PR TITLE
Removed references to the origional "stable" helm chart repo

### DIFF
--- a/AppDev/cloud-native/kubernetes/base-kubernetes/kubernetes-base-labs.md
+++ b/AppDev/cloud-native/kubernetes/base-kubernetes/kubernetes-base-labs.md
@@ -37,14 +37,7 @@ Helm is the tool we will be using to install standard software into Kubernetes. 
 
 The OCI Cloud Shell has helm already installed for you, however it does not know what repositories to use for the helm charts. We need to tell helm what repositories to use.
 
-  1. Run the following command to add the core stable repo to helm :
-  
-  - `helm repo add stable https://kubernetes-charts.storage.googleapis.com/`
-  
-  ```
-"stable" has been added to your repositories
-```
-  2. Now add the dashboard repo
+  1. Run the following command to add the dashboard repo to helm
   
   - `helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/`
   
@@ -52,24 +45,22 @@ The OCI Cloud Shell has helm already installed for you, however it does not know
 "kubernetes-dashboard" has been added to your repositories
  ```
  
-  3. To can get the current list of repositories run the following command :
+  2. To can get the current list of repositories run the following command :
   
   - `helm repo list`
   
   ```                                            
-NAME                    URL                                              
-stable                  https://kubernetes-charts.storage.googleapis.com/
+NAME                    URL         
 kubernetes-dashboard    https://kubernetes.github.io/dashboard/  
 ```
     
-  4. Lastly let's update the helm cache, run the following command :
+  3. Lastly let's update the helm cache, run the following command :
   
   - `helm repo update`
 
   ```
 Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "kubernetes-dashboard" chart repository
-...Successfully got an update from the "stable" chart repository
 Update Complete. ⎈ Happy Helming!⎈ 
 ```
 
@@ -690,7 +681,6 @@ secret/tls-secret created
 Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "kubernetes-dashboard" chart repository
 ...Successfully got an update from the "ingress-nginx" chart repository
-...Successfully got an update from the "stable" chart repository
 ```
 
   6. Run the following command to install **ingress-nginx** using Helm 3:

--- a/AppDev/cloud-native/kubernetes/cloud-native-labs/horizontal-scaling/auto-scaling.md
+++ b/AppDev/cloud-native/kubernetes/cloud-native-labs/horizontal-scaling/auto-scaling.md
@@ -43,7 +43,7 @@ For now we are going to use the simplest approach of the metrics server.
 
 ### Step 1a: Installing the metrics server
 
-  1. Install the helm char repo that contains the metrics server
+  1. Install a helm repo that contains the chart for the metrics server
   
   - `helm repo add bitnami https://charts.bitnami.com/bitnami`
   
@@ -56,7 +56,6 @@ Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "kubernetes-dashboard" chart repository
 ...Successfully got an update from the "ingress-nginx" chart repository
 ...Successfully got an update from the "bitnami" chart repository
-...Successfully got an update from the "stable" chart repository
 
 ```
 
@@ -510,7 +509,7 @@ The number of pods is now back to one (it may be that you get a report of 2 pods
 ## Step 3: Autoscaling on other metrics
 We have here looked at how to use CPU and memory to determine when to autoscale, that may be a good solution, or it may not. Kubernetes autoscaling can support the use of other metrics to manage autoscaling.
 
-These other metrics can be other Kuberneties metrics (known as custom metrics) for example the number of requests to the ingress controller, or (with the provision of the [Prometheus Adaptor (helm chart)](https://github.com/helm/charts/tree/master/stable/prometheus-adapter)) any metric that Prometheus gathers. This last is especially useful as it means you can autoscale on what are effectively business metrics.
+These other metrics can be other Kuberneties metrics (known as custom metrics) for example the number of requests to the ingress controller, or (with the provision of the [Prometheus Adaptor (helm chart)](https://github.com/prometheus-community/helm-charts)) any metric that Prometheus gathers. This last is especially useful as it means you can autoscale on what are effectively business metrics.
 
 It's also possible to autoscale on metrics provides from outside Kubernetes (these are known as external metrics). this is only recommended as a last resort however due to the security implications, and custom metrics are preferred.
 

--- a/AppDev/cloud-native/kubernetes/further-information/further-information.md
+++ b/AppDev/cloud-native/kubernetes/further-information/further-information.md
@@ -2,13 +2,9 @@
 While writing these labs I came across many web pages. Ones that I think are especially useful are detailed in the sections below
 
 ## Helm
-Helm has been used here to install a number of Kubernetes servcies. See [Helm website](https://helm.sh) for details and if you need to download it there are details in the [Helm web page](https://helm.sh/docs/intro/install/)
+Helm has been used here to install a number of Kubernetes services. See [Helm website](https://helm.sh) for details and if you need to download it there are details in the [Helm web page](https://helm.sh/docs/intro/install/)
 
-If you download Helm version 3 it does not come with a pre-configured chart repository, but the master repo maintained by the helm team (and the one used to download the charts used in the labs) can be added using the following command
-
-```
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-```
+If you download Helm version 3 it does not come with a pre-configured chart repository. The master repo used to be at `kubernetes-charts.storage.googleapis.com` however in late 2020 it was deprecated when the help project stopped maintaining it's chart repo, so you may experience access problems, as well as it not containing current charts. Charts are now managed by the individual projects / companies (e.g. `https://kubernetes.github.io/dashboard/` for the dashboard). There are some companies that maintain a collection of helm charts from multiple other sources which may be suitable if you can't find the individual project charts (E.g. The Bitnami helm chart repo at `https://charts.bitnami.com/bitnami`) 
 
 ## Ingress
 For more information on [Nginx Ingress](https://matthewpalmer.net/kubernetes-app-developer/articles/kubernetes-ingress-guide-nginx-example.html) (this also looks in more detail at the benefits / disadvantages of using an Ingress vs Load Balancer)

--- a/AppDev/cloud-native/kubernetes/management/logging/log-capture-for-processing.md
+++ b/AppDev/cloud-native/kubernetes/management/logging/log-capture-for-processing.md
@@ -71,7 +71,7 @@ namespace/logging created
 
 Now let's use helm to install the elastic search engine into the logging namespace
 
-  2. First if you haven't already done it add the bitnami help repository.
+  2. First add the bitnami helm chart repository.
 
   - `helm repo add bitnami https://charts.bitnami.com/bitnami`
   
@@ -89,7 +89,6 @@ Note that depending on what modules you have already done you may get a message 
 Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "kubernetes-dashboard" chart repository
 ...Successfully got an update from the "bitnami" chart repository
-...Successfully got an update from the "stable" chart repository
 Update Complete. ⎈ Happy Helming!⎈ 
 ```
 

--- a/AppDev/cloud-native/kubernetes/monitoring-kubernetes/monitoring-with-prometheus-lab.md
+++ b/AppDev/cloud-native/kubernetes/monitoring-kubernetes/monitoring-with-prometheus-lab.md
@@ -71,7 +71,6 @@ Now update the repository information
 Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "kubernetes-dashboard" chart repository
 ...Successfully got an update from the "prometheus-community" chart repository
-...Successfully got an update from the "stable" chart repository
 Update Complete. ⎈Happy Helming!⎈
 ```
   

--- a/AppDev/cloud-native/kubernetes/monitoring-kubernetes/visualizing-with-grafana-lab.md
+++ b/AppDev/cloud-native/kubernetes/monitoring-kubernetes/visualizing-with-grafana-lab.md
@@ -39,7 +39,7 @@ For this lab we will use a small subset of the open source features only.
 ## Step 2: Installing Grafana
 Like many other Kubernetes services Grafana can be installed using helm. By default the helm chart does not create a volume for the storage of the grafana configuration. This would be a problem in a production environment, so we're going to use the persistent storage option defined inthe helm chart for Grafana to create a storage volume. 
 
-  1. Create the Helm repository entry for Grafana 
+  1. Add the Helm repository entry for Grafana 
   
   - `helm repo add bitnami https://charts.bitnami.com/bitnami`
 
@@ -57,7 +57,6 @@ If you have already added the bitnami repository in another module you'll be tol
 Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "kubernetes-dashboard" chart repository
 ...Successfully got an update from the "bitnami" chart repository
-...Successfully got an update from the "stable" chart repository
 Update Complete. ⎈ Happy Helming!⎈ 
 ```
 


### PR DESCRIPTION
The labs still had an entry to add the old "stable" helm chart repo which has now been deprecated. Attempts to do chart repo updates with this produced an error which was not fatal (we didn't actually use any charts from the "stable" repo) but it did look scary. These updates removed the "add" of the "stable" repo, and also removed references in the helm update output to that chart repo