### PR TITLE
Support Template Update for: OCI workshops in oracle/cloudtestdrive

### DIFF
--- a/AppDev/cloud-native/.vscode/settings.json
+++ b/AppDev/cloud-native/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/AppDev/cloud-native/docker/docker-labs.md
+++ b/AppDev/cloud-native/docker/docker-labs.md
@@ -889,10 +889,3 @@ If you are doing only the Helidon and Docker lab you've finished. If you're doin
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/helidon/helidon-cloud-native/helidon-cloud-native.md
+++ b/AppDev/cloud-native/helidon/helidon-cloud-native/helidon-cloud-native.md
@@ -255,10 +255,4 @@ If you are only doing the Helidon labs and do not want to do the **Self document
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
 
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/helidon/helidon-core/helidon-core.md
+++ b/AppDev/cloud-native/helidon/helidon-core/helidon-core.md
@@ -1864,10 +1864,3 @@ The next lab in the *Helidon for Cloud Native* section is  **Databases and Helid
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/helidon/helidon-data/accessing-the-context.md
+++ b/AppDev/cloud-native/helidon/helidon-data/accessing-the-context.md
@@ -155,10 +155,3 @@ The next lab in the Helidon labs is **Communicating between microservcies with H
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/helidon/helidon-data/helidon-data.md
+++ b/AppDev/cloud-native/helidon/helidon-data/helidon-data.md
@@ -653,10 +653,3 @@ The next lab in the Helidon core labs is **Communicating between microservices w
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/helidon/helidon-open-api/helidon-open-api.md
+++ b/AppDev/cloud-native/helidon/helidon-open-api/helidon-open-api.md
@@ -1246,10 +1246,3 @@ If you are only doing the Helidon labs then thank you for your time and attentio
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/helidon/helidon-operations/helidon-operations.md
+++ b/AppDev/cloud-native/helidon/helidon-operations/helidon-operations.md
@@ -526,10 +526,3 @@ The next lab in the Helidon core labs is **Cloud Native support in Helidon**
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/helidon/helidon-to-other-microservices/helidon-to-other-microservices.md
+++ b/AppDev/cloud-native/helidon/helidon-to-other-microservices/helidon-to-other-microservices.md
@@ -449,10 +449,4 @@ The next lab in the Helidon core labs is **Operations support with Helidon**
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
 
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/helidon/helidon-to-other-microservices/non-helidon-rest-clients.md
+++ b/AppDev/cloud-native/helidon/helidon-to-other-microservices/non-helidon-rest-clients.md
@@ -171,10 +171,3 @@ The next lab in the Helidon labs is **Operations support with Helidon**
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/helidon/setup/setup.md
+++ b/AppDev/cloud-native/helidon/setup/setup.md
@@ -195,10 +195,3 @@ Congratulations, you have successfully setup your VM with the template code. You
 * **Author** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/kubernetes/base-kubernetes/kubernetes-base-labs.md
+++ b/AppDev/cloud-native/kubernetes/base-kubernetes/kubernetes-base-labs.md
@@ -2277,9 +2277,3 @@ You have reached the end of this module, the next section is **Cloud Native with
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/kubernetes/base-kubernetes/securing-the-rest-endpoint.md
+++ b/AppDev/cloud-native/kubernetes/base-kubernetes/securing-the-rest-endpoint.md
@@ -89,9 +89,3 @@ The next module is the **Cloud native availability with Kubernetes** module
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/kubernetes/cloud-native-labs/health-readiness-liveness/health-liveness-readiness.md
+++ b/AppDev/cloud-native/kubernetes/cloud-native-labs/health-readiness-liveness/health-liveness-readiness.md
@@ -967,9 +967,3 @@ You have reached the end of this section of the lab. The next module is `Horizon
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/kubernetes/cloud-native-labs/horizontal-scaling/auto-scaling.md
+++ b/AppDev/cloud-native/kubernetes/cloud-native-labs/horizontal-scaling/auto-scaling.md
@@ -535,9 +535,3 @@ You have reached the end of this section of the lab. The next module is `Rolling
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/kubernetes/cloud-native-labs/horizontal-scaling/horizontal-scaling.md
+++ b/AppDev/cloud-native/kubernetes/cloud-native-labs/horizontal-scaling/horizontal-scaling.md
@@ -245,9 +245,3 @@ You have reached the end of this section of the lab. The next module is `Auto sc
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/kubernetes/cloud-native-labs/rolling-updates/rolling-updates.md
+++ b/AppDev/cloud-native/kubernetes/cloud-native-labs/rolling-updates/rolling-updates.md
@@ -698,9 +698,3 @@ If you are doing the optional modules version of this course then you can chose 
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/kubernetes/further-information/further-information.md
+++ b/AppDev/cloud-native/kubernetes/further-information/further-information.md
@@ -52,9 +52,3 @@ You have reached the end of this section of the lab and of the Kubernetes sectio
 
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/kubernetes/management/logging/log-capture-for-archive.md
+++ b/AppDev/cloud-native/kubernetes/management/logging/log-capture-for-archive.md
@@ -698,9 +698,3 @@ You can chose from the various Kubernetes optional module sets.
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/kubernetes/management/logging/log-capture-for-processing.md
+++ b/AppDev/cloud-native/kubernetes/management/logging/log-capture-for-processing.md
@@ -498,9 +498,3 @@ You can chose from the various Kubernetes optional module sets.
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/kubernetes/monitoring-kubernetes/monitoring-with-prometheus-lab.md
+++ b/AppDev/cloud-native/kubernetes/monitoring-kubernetes/monitoring-with-prometheus-lab.md
@@ -570,9 +570,3 @@ You can move on to the `Visualizing with Grafana` module which builds on this mo
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/kubernetes/monitoring-kubernetes/visualizing-with-grafana-lab.md
+++ b/AppDev/cloud-native/kubernetes/monitoring-kubernetes/visualizing-with-grafana-lab.md
@@ -554,9 +554,3 @@ You can chose from the various Kubernetes optional module sets.
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/kubernetes/service-mesh/linkerd-exploring-traffic-splits.md
+++ b/AppDev/cloud-native/kubernetes/service-mesh/linkerd-exploring-traffic-splits.md
@@ -948,17 +948,3 @@ You can chose from the remaining **Linkerd service mesh** modules or switch to o
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Charles Pretzer, Bouyant, Inc for reviewing and sanity checking parts of this document.
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
----
-
-You have reached the end of this lab module!!
-
-Acknowledgments. I'd like to thank Charles Pretzer of Bouyant, Inc for reviewing and sanity checking parts of this document.
-
-Use your **back** button to return to the lab sequence document to access further service mesh modules.

--- a/AppDev/cloud-native/kubernetes/service-mesh/linkerd-install.md
+++ b/AppDev/cloud-native/kubernetes/service-mesh/linkerd-install.md
@@ -1332,9 +1332,3 @@ You can chose from the remaining `Linkerd service mesh` modules or switch to one
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Charles Pretzer, Bouyant, Inc for reviewing and sanity checking parts of this document.
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/kubernetes/service-mesh/linkerd-monitoring-traffic-flows.md
+++ b/AppDev/cloud-native/kubernetes/service-mesh/linkerd-monitoring-traffic-flows.md
@@ -377,9 +377,3 @@ You can chose from the remaining **Linkerd service mesh** modules or switch to o
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Charles Pretzer, Bouyant, Inc for reviewing and sanity checking parts of this document.
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/kubernetes/service-mesh/linkerd-uninstall.md
+++ b/AppDev/cloud-native/kubernetes/service-mesh/linkerd-uninstall.md
@@ -205,9 +205,3 @@ You can chose from the other Kubernetes optional module sets.
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Charles Pretzer, Bouyant, Inc for reviewing and sanity checking parts of this document.
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/kubernetes/service-mesh/linkerd-using-to-troubleshoot-problems.md
+++ b/AppDev/cloud-native/kubernetes/service-mesh/linkerd-using-to-troubleshoot-problems.md
@@ -350,9 +350,3 @@ You can chose from the remaining `Linkerd service mesh` modules or switch to one
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Charles Pretzer, Bouyant, Inc for reviewing and sanity checking parts of this document.
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/kubernetes/setup/cloud-shell-setup.md
+++ b/AppDev/cloud-native/kubernetes/setup/cloud-shell-setup.md
@@ -186,10 +186,3 @@ Go to the **Setting up the cluster and getting your services running in Kubernet
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Contributor** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
- 

--- a/AppDev/cloud-native/livelabs/combined/helidon-docker-complete/combined-helidon-docker-complete.md
+++ b/AppDev/cloud-native/livelabs/combined/helidon-docker-complete/combined-helidon-docker-complete.md
@@ -261,10 +261,3 @@ When you finish the modules in this lab the take the time for a cup of tea (or o
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/livelabs/combined/helidon-docker-complete/manifest.json
+++ b/AppDev/cloud-native/livelabs/combined/helidon-docker-complete/manifest.json
@@ -1,5 +1,5 @@
 {
-  "workshoptitle": "Creating Microservices with Helidon MP and Docker - Extended",
+  "workshoptitle": "Creating Microservices with Helidon MP and Packaging using Docker - Extended",
   "help": "livelabs-help-oci_us@oracle.com",
 	"tutorials": [
         {

--- a/AppDev/cloud-native/livelabs/combined/helidon-docker-complete/manifest.json
+++ b/AppDev/cloud-native/livelabs/combined/helidon-docker-complete/manifest.json
@@ -1,12 +1,14 @@
 {
-    "tutorials": [
-        {
-          "title": "Prerequisites",
-          "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
-        },
+  "workshoptitle": "Creating Microservices with Helidon MP and Docker - Extended",
+  "help": "livelabs-help-oci_us@oracle.com",
+	"tutorials": [
         {
           "title": "Labs introduction",
           "filename":"combined-helidon-docker-complete.md"
+        },
+        {
+          "title": "Getting Started",
+          "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
         },
         {
           "title": "Setup your tenancy",
@@ -55,6 +57,11 @@
         {
           "title": "Docker - Docker lab",
           "filename": "../../../docker/docker-labs.md"
+        },
+        {
+          "title": "Need Help?",
+          "description": "Solutions to Common Problems and Directions for Receiving Live Help",
+          "filename": "https://raw.githubusercontent.com/oracle/learning-library/master/oci-library/need-help/need-help-livelabs.md"
         }
     ]
 }

--- a/AppDev/cloud-native/livelabs/combined/helidon-docker-core/combined-helidon-docker-core.md
+++ b/AppDev/cloud-native/livelabs/combined/helidon-docker-core/combined-helidon-docker-core.md
@@ -238,10 +238,3 @@ When you finish the modules in this lab the take the time for a cup of tea (or o
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/livelabs/combined/helidon-docker-core/manifest.json
+++ b/AppDev/cloud-native/livelabs/combined/helidon-docker-core/manifest.json
@@ -1,12 +1,14 @@
 {
-    "tutorials": [
-      {
-        "title": "Prerequisites",
-        "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
-      },
-      {
-        "title": "Labs introduction",
+  "workshoptitle": "Creating Microservices with Helidon MP and Docker",
+  "help": "livelabs-help-oci_us@oracle.com",
+	"tutorials": [
+        {
+          "title": "Labs introduction",
           "filename":"combined-helidon-docker-core.md"
+        },
+        {
+          "title": "Getting Started",
+          "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
         },
         {
           "title": "Setup your tenancy",
@@ -20,11 +22,11 @@
           "title": "Helidon - Part 1: Core Helidon ",
           "filename": "../../../helidon/helidon-core/helidon-core.md"
         },
-		{
+		    {
           "title": "Helidon - Part 2: Database and Helidon",
           "filename": "../../../helidon/helidon-data/helidon-data.md"
         },
-		{
+		    {
           "title": "Helidon - Part 3: Communicating between microservices with Helidon",
           "filename": "../../../helidon/helidon-to-other-microservices/helidon-to-other-microservices.md"
         },
@@ -39,6 +41,11 @@
         {
           "title": "Docker - Docker lab",
           "filename": "../../../docker/docker-labs.md"
+        },
+        {
+          "title": "Need Help?",
+          "description": "Solutions to Common Problems and Directions for Receiving Live Help",
+          "filename": "https://raw.githubusercontent.com/oracle/learning-library/master/oci-library/need-help/need-help-livelabs.md"
         }
     ]
 }

--- a/AppDev/cloud-native/livelabs/combined/helidon-docker-kubernetes-complete/combined-helidon-docker-kubernetes-complete.md
+++ b/AppDev/cloud-native/livelabs/combined/helidon-docker-kubernetes-complete/combined-helidon-docker-kubernetes-complete.md
@@ -415,10 +415,4 @@ When you finish the modules in this lab the take the time for a cup of tea (or o
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
 
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/livelabs/combined/helidon-docker-kubernetes-complete/manifest.json
+++ b/AppDev/cloud-native/livelabs/combined/helidon-docker-kubernetes-complete/manifest.json
@@ -1,12 +1,14 @@
 {
-    "tutorials": [
-      {
-        "title": "Prerequisites",
-        "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
-      },
-      {
-        "title": "Labs introduction",
+  "workshoptitle": "Migration of Monolith to Cloud Native - Extended",
+  "help": "livelabs-help-oci_us@oracle.com",
+	"tutorials": [
+        {
+          "title": "Labs introduction",
           "filename":"combined-helidon-docker-kubernetes-complete.md"
+        },
+        {
+          "title": "Getting Started",
+          "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
         },
         {
           "title": "Setup your tenancy",
@@ -20,19 +22,19 @@
           "title": "Helidon - Part 1: Core Helidon ",
           "filename": "../../../helidon/helidon-core/helidon-core.md"
         },
-		{
+		    {
           "title": "Helidon - Part 2: Database and Helidon",
           "filename": "../../../helidon/helidon-data/helidon-data.md"
         },
-		{
+		    {
           "title": "Helidon - Optional Part 2a: Accessing the request context",
           "filename": "../../../helidon/helidon-data/accessing-the-context.md"
         },
-		{
+		    {
           "title": "Helidon - Part 3: Communicating between microservices with Helidon",
           "filename": "../../../helidon/helidon-to-other-microservices/helidon-to-other-microservices.md"
         },
-		{
+		    {
           "title": "Helidon - Optional Part 3a: Communicating from non Helidon clients",
           "filename": "../../../helidon/helidon-to-other-microservices/non-helidon-rest-clients.md"
         },
@@ -123,6 +125,11 @@
         {
           "title": "Further Information on Kubernetes",
           "filename": "../../../kubernetes/further-information/further-information.md"
+        },
+        {
+          "title": "Need Help?",
+          "description": "Solutions to Common Problems and Directions for Receiving Live Help",
+          "filename": "https://raw.githubusercontent.com/oracle/learning-library/master/oci-library/need-help/need-help-livelabs.md"
         }
     ]
 }

--- a/AppDev/cloud-native/livelabs/combined/helidon-docker-kubernetes-core/combined-helidon-docker-kubernetes-core.md
+++ b/AppDev/cloud-native/livelabs/combined/helidon-docker-kubernetes-core/combined-helidon-docker-kubernetes-core.md
@@ -307,10 +307,3 @@ When you finish the modules in this lab the take the time for a cup of tea (or o
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/livelabs/combined/helidon-docker-kubernetes-core/manifest.json
+++ b/AppDev/cloud-native/livelabs/combined/helidon-docker-kubernetes-core/manifest.json
@@ -1,12 +1,14 @@
 {
-    "tutorials": [
-      {
-        "title": "Prerequisites",
-        "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
-      },
-      {
-        "title": "Labs introduction",
+  "workshoptitle": "Migration of Monolith to Cloud Native",
+  "help": "livelabs-help-oci_us@oracle.com",
+	"tutorials": [
+        {
+          "title": "Labs introduction",
           "filename":"combined-helidon-docker-kubernetes-core.md"
+        },
+        {
+          "title": "Getting Started",
+          "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
         },
         {
           "title": "Setup your tenancy",
@@ -71,6 +73,11 @@
         {
           "title": "Further Information on Kubernetes",
           "filename": "../../../kubernetes/further-information/further-information.md"
+        },
+        {
+          "title": "Need Help?",
+          "description": "Solutions to Common Problems and Directions for Receiving Live Help",
+          "filename": "https://raw.githubusercontent.com/oracle/learning-library/master/oci-library/need-help/need-help-livelabs.md"
         }
     ]
 }

--- a/AppDev/cloud-native/livelabs/individual/helidon/helidon-complete/helidon-complete.md
+++ b/AppDev/cloud-native/livelabs/individual/helidon/helidon-complete/helidon-complete.md
@@ -255,10 +255,3 @@ When you finish the modules in this lab the take the time for a cup of tea (or o
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/livelabs/individual/helidon/helidon-complete/manifest.json
+++ b/AppDev/cloud-native/livelabs/individual/helidon/helidon-complete/manifest.json
@@ -1,12 +1,14 @@
 {
-    "tutorials": [
-      {
-        "title": "Prerequisites",
-        "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
-      },
-      {
-        "title": "Labs introduction",
+  "workshoptitle": "Using Helidon to Create Microservices from a Monolith - Extended",
+  "help": "livelabs-help-oci_us@oracle.com",
+	"tutorials": [
+        {
+          "title": "Labs introduction",
           "filename":"helidon-complete.md"
+        },
+        {
+          "title": "Getting Started",
+          "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
         },
         {
           "title": "Setup your tenancy",
@@ -51,6 +53,11 @@
         {
           "title": "Optional lab 1: Self documenting API support in Helidon",
           "filename": "../../../../helidon/helidon-open-api/helidon-open-api.md"
+        },
+        {
+          "title": "Need Help?",
+          "description": "Solutions to Common Problems and Directions for Receiving Live Help",
+          "filename": "https://raw.githubusercontent.com/oracle/learning-library/master/oci-library/need-help/need-help-livelabs.md"
         }
     ]
 }

--- a/AppDev/cloud-native/livelabs/individual/helidon/helidon-core/helidon-core.md
+++ b/AppDev/cloud-native/livelabs/individual/helidon/helidon-core/helidon-core.md
@@ -255,10 +255,3 @@ When you finish the modules in this lab the take the time for a cup of tea (or o
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/livelabs/individual/helidon/helidon-core/manifest.json
+++ b/AppDev/cloud-native/livelabs/individual/helidon/helidon-core/manifest.json
@@ -1,12 +1,14 @@
 {
-    "tutorials": [
-      {
-        "title": "Prerequisites",
-        "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
-      },
-      {
-        "title": "Labs introduction",
+  "workshoptitle": "Using Helidon to Create Microservices from a Monolith",
+  "help": "livelabs-help-oci_us@oracle.com",
+	"tutorials": [
+        {
+          "title": "Labs introduction",
           "filename":"helidon-core.md"
+        },
+        {
+          "title": "Getting Started",
+          "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
         },
         {
           "title": "Setup your tenancy",
@@ -35,6 +37,11 @@
         {
           "title": "Part 5: Cloud Native support in Helidon",
           "filename": "../../../../helidon/helidon-cloud-native/helidon-cloud-native.md"
+        },
+        {
+          "title": "Need Help?",
+          "description": "Solutions to Common Problems and Directions for Receiving Live Help",
+          "filename": "https://raw.githubusercontent.com/oracle/learning-library/master/oci-library/need-help/need-help-livelabs.md"
         }
     ]
 }

--- a/AppDev/cloud-native/livelabs/individual/kubernetes/kubernetes-complete/kubernetes-complete.md
+++ b/AppDev/cloud-native/livelabs/individual/kubernetes/kubernetes-complete/kubernetes-complete.md
@@ -215,10 +215,3 @@ When you finish the modules in this lab the take the time for a cup of tea (or o
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/livelabs/individual/kubernetes/kubernetes-complete/manifest.json
+++ b/AppDev/cloud-native/livelabs/individual/kubernetes/kubernetes-complete/manifest.json
@@ -1,12 +1,14 @@
 {
-    "tutorials": [
-      {
-        "title": "Prerequisites",
-        "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
-      },
-      {
-        "title": "Labs introduction",
+  "workshoptitle": "Deploying Microservices in Kubernetes and OCI Supporting Features",
+  "help": "livelabs-help-oci_us@oracle.com",
+	"tutorials": [
+        {
+          "title": "Labs introduction",
           "filename":"kubernetes-complete.md"
+        },
+        {
+          "title": "Getting Started",
+          "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
         },
         {
           "title": "Tenancy Setup for the Kubernetes Labs",
@@ -79,6 +81,11 @@
         {
           "title": "Further Information on Kubernetes",
           "filename": "../../../../kubernetes/further-information/further-information.md"
+        },
+        {
+          "title": "Need Help?",
+          "description": "Solutions to Common Problems and Directions for Receiving Live Help",
+          "filename": "https://raw.githubusercontent.com/oracle/learning-library/master/oci-library/need-help/need-help-livelabs.md"
         }
     ]
 }

--- a/AppDev/cloud-native/livelabs/individual/kubernetes/kubernetes-core/kubernetes-core.md
+++ b/AppDev/cloud-native/livelabs/individual/kubernetes/kubernetes-core/kubernetes-core.md
@@ -108,10 +108,3 @@ When you finish the modules in this lab the take the time for a cup of tea (or o
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/livelabs/individual/kubernetes/kubernetes-core/manifest.json
+++ b/AppDev/cloud-native/livelabs/individual/kubernetes/kubernetes-core/manifest.json
@@ -1,12 +1,14 @@
 {
-    "tutorials": [
-      {
-        "title": "Prerequisites",
-        "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
-      },
-      {
-        "title": "Labs introduction",
+  "workshoptitle": "Deploying microservices in Kubernetes",
+  "help": "livelabs-help-oci_us@oracle.com",
+	"tutorials": [
+        {
+          "title": "Labs introduction",
           "filename":"kubernetes-core.md"
+        },
+        {
+          "title": "Getting Started",
+          "filename":"https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
         },
         {
           "title": "Tenancy Setup for the Kubernetes Labs",
@@ -43,6 +45,11 @@
         {
           "title": "Further Information on Kubernetes",
           "filename": "../../../../kubernetes/further-information/further-information.md"
+        },
+        {
+          "title": "Need Help?",
+          "description": "Solutions to Common Problems and Directions for Receiving Live Help",
+          "filename": "https://raw.githubusercontent.com/oracle/learning-library/master/oci-library/need-help/need-help-livelabs.md"
         }
     ]
 }

--- a/AppDev/cloud-native/manual-setup/create-kubernetes-cluster.md
+++ b/AppDev/cloud-native/manual-setup/create-kubernetes-cluster.md
@@ -93,9 +93,3 @@ You can move on to the **Cloud Shell Setup for the Kubernetes Labs** module whil
 * **Author** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Contributor** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.

--- a/AppDev/cloud-native/manual-setup/full-setup-free-tier-image-import-version.md
+++ b/AppDev/cloud-native/manual-setup/full-setup-free-tier-image-import-version.md
@@ -673,10 +673,3 @@ Congratulations, you have successfully prepared your tenancy to do the labs, the
 * **Author** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/manual-setup/full-setup-free-tier.md
+++ b/AppDev/cloud-native/manual-setup/full-setup-free-tier.md
@@ -562,10 +562,3 @@ Congratulations, you have successfully prepared your tenancy to do the labs, the
 * **Author** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, February 2021
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/manual-setup/kubernetes-setup.md
+++ b/AppDev/cloud-native/manual-setup/kubernetes-setup.md
@@ -161,10 +161,3 @@ Go to the **Create your Kubernetes cluster** lab
 * **Author** - Jan Leemans, Director Business Development, EMEA Divisional Technology
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/manual-setup/terminate-db-network-and-compartment.md
+++ b/AppDev/cloud-native/manual-setup/terminate-db-network-and-compartment.md
@@ -92,11 +92,3 @@ That's all folks, you're finished. We hope that you have enjoyed doing the labs.
 
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Last Updated By** - Tim Graves, November 2020
-
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/manual-setup/terminate-dev-vm.md
+++ b/AppDev/cloud-native/manual-setup/terminate-dev-vm.md
@@ -73,10 +73,3 @@ Depending on the modules you have done you may wish to also delete the Kubernete
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.

--- a/AppDev/cloud-native/manual-setup/terminate-kubernetes-cluster.md
+++ b/AppDev/cloud-native/manual-setup/terminate-kubernetes-cluster.md
@@ -106,10 +106,3 @@ Depending on the modules you have done you may wish to also delete the database,
 * **Author** - Tim Graves, Cloud Native Solutions Architect, EMEA OCI Centre of Excellence
 * **Last Updated By** - Tim Graves, November 2020
 
-## Need Help ?
-
-If you are doing this module as part of an instructor led lab then please just ask the instructor.
-
-If you are working through this module self guided then please submit feedback or ask for help using our [LiveLabs Support Forum](https://community.oracle.com/tech/developers/categories/OCI%20Native%20Development). Please click the **Log In** button and login using your Oracle Account. Click the **Ask A Question** button to the left to start a *New Discussion* or *Ask a Question*.  Please include your workshop name and lab name.  You can also include screenshots and attach files.  Engage directly with the author of the workshop.
-
-If you do not have an Oracle Account, click [here](https://profile.oracle.com/myprofile/account/create-account.jspx) to create one.


### PR DESCRIPTION
Support Template Update for all workshops under:
cloudtestdrive/AppDev/cloud-native

Added workshoptitles to relevant workshops so they appear in the auto generated email.