### PR TITLE
switch from EC to RSA based certs as the API GW requires those

### DIFF
--- a/AppDev/cloud-native/kubernetes/base-kubernetes/kubernetes-base-labs.md
+++ b/AppDev/cloud-native/kubernetes/base-kubernetes/kubernetes-base-labs.md
@@ -1056,7 +1056,7 @@ To enable the lab to complete in a reasonable time we will therefore be generati
 
   3. Run the following command to generate a certificate (you installed the step command in the cloud shell setup). The value of the IP address of the Ingress controllers load balancer is in `$EXTERNAL_IP` and will be replaced in the command below automatically.
 
-  - `$HOME/keys/step certificate create store.$EXTERNAL_IP.nip.io tls-store-$EXTERNAL_IP.crt tls-store-$EXTERNAL_IP.key --profile leaf  --not-after 8760h --no-password --insecure --ca $HOME/keys/root.crt --ca-key $HOME/keys/root.key`
+  - `$HOME/keys/step certificate create store.$EXTERNAL_IP.nip.io tls-store-$EXTERNAL_IP.crt tls-store-$EXTERNAL_IP.key --profile leaf  --not-after 8760h --no-password --insecure --kty=RSA --ca $HOME/keys/root.crt --ca-key $HOME/keys/root.key`
 
   ```
 Your certificate has been saved in tls-store-123.456.789.123.crt.

--- a/AppDev/cloud-native/kubernetes/management/logging/log-capture-for-processing.md
+++ b/AppDev/cloud-native/kubernetes/management/logging/log-capture-for-processing.md
@@ -175,7 +175,7 @@ secret/web-ingress-auth created
 
   3. Let's create the certificate for this service. In the OCI cloud shell type the following.
   
-  - `$HOME/keys/step certificate create search.logging.$EXTERNAL_LP.nip.io tls-search-$EXTERNAL_IP.crt tls-search-$EXTERNAL_IP.key  --profile leaf  --not-after 8760h --no-password --insecure --ca $HOME/keys/root.crt --ca-key $HOME/keys/root.key`
+  - `$HOME/keys/step certificate create search.logging.$EXTERNAL_LP.nip.io tls-search-$EXTERNAL_IP.crt tls-search-$EXTERNAL_IP.key  --profile leaf  --not-after 8760h --no-password --insecure --kty=RSA --ca $HOME/keys/root.crt --ca-key $HOME/keys/root.key`
   
   ```
   Your certificate has been saved in tls-search-123.456.789.123.crt.

--- a/AppDev/cloud-native/kubernetes/monitoring-kubernetes/monitoring-with-prometheus-lab.md
+++ b/AppDev/cloud-native/kubernetes/monitoring-kubernetes/monitoring-with-prometheus-lab.md
@@ -168,7 +168,7 @@ secret/web-ingress-auth created
 
   5. To provide secure access for the ingress we will set this up with a TLS connection , that requires that we create a certificate for the ingress rule. In production you would of course use a proper certificate, but for this lab we're going to use the self-signed root certificate we created in the cloud shell setup.
   
-  - `$HOME/keys/step certificate create prometheus.monitoring.$EXTERNAL_IP.nip.io tls-prometheus-$EXTERNAL_IP.crt tls-prometheus-$EXTERNAL_IP.key --profile leaf  --not-after 8760h --no-password --insecure --ca $HOME/keys/root.crt --ca-key $HOME/keys/root.key`
+  - `$HOME/keys/step certificate create prometheus.monitoring.$EXTERNAL_IP.nip.io tls-prometheus-$EXTERNAL_IP.crt tls-prometheus-$EXTERNAL_IP.key --profile leaf  --not-after 8760h --no-password --insecure --kty=RSA --ca $HOME/keys/root.crt --ca-key $HOME/keys/root.key`
   
   ```
   Your certificate has been saved in tls-prometheus-123.456.789.123.crt.

--- a/AppDev/cloud-native/kubernetes/monitoring-kubernetes/visualizing-with-grafana-lab.md
+++ b/AppDev/cloud-native/kubernetes/monitoring-kubernetes/visualizing-with-grafana-lab.md
@@ -131,7 +131,7 @@ ingress-nginx-controller-admission   ClusterIP      10.96.216.33    <none>      
 
   4. Create a certificate to protect the connection, we'll use step which we installed in the cloud shell setup section of the lab.
   
-  - `$HOME/keys/step certificate create grafana.monitoring.$EXTERNAL_IP.nip.io tls-grafana-$EXTERNAL_IP.crt tls-grafana-$EXTERNAL_IP.key --profile leaf  --not-after 8760h --no-password --insecure --ca $HOME/keys/root.crt --ca-key $HOME/keys/root.key`
+  - `$HOME/keys/step certificate create grafana.monitoring.$EXTERNAL_IP.nip.io tls-grafana-$EXTERNAL_IP.crt tls-grafana-$EXTERNAL_IP.key --profile leaf  --not-after 8760h --no-password --insecure --kty=RSA --ca $HOME/keys/root.crt --ca-key $HOME/keys/root.key`
   
   ```
   Your certificate has been saved in tls-grafana-123.456.789.123.crt.

--- a/AppDev/cloud-native/kubernetes/service-mesh/linkerd-install.md
+++ b/AppDev/cloud-native/kubernetes/service-mesh/linkerd-install.md
@@ -642,7 +642,7 @@ We will use step to help us here, it was installed when you did the cloud shell 
 
   2. In the OCI Cloud shell run the following.
   
-  - `$HOME/keys/step certificate create linkerd.$EXTERNAL_IP.nip.io tls-linkerd-$EXTERNAL_IP.crt tls-linkerd-$EXTERNAL_IP.key --profile leaf  --not-after 8760h --no-password --insecure --ca $HOME/keys/root.crt --ca-key $HOME/keys/root.key`
+  - `$HOME/keys/step certificate create linkerd.$EXTERNAL_IP.nip.io tls-linkerd-$EXTERNAL_IP.crt tls-linkerd-$EXTERNAL_IP.key --profile leaf  --not-after 8760h --no-password --insecure --kty=RSA --ca $HOME/keys/root.crt --ca-key $HOME/keys/root.key`
 
   ```
   Your certificate has been saved in tls-linkerd-123.456.789.123.crt.

--- a/AppDev/cloud-native/scripted-setup/script-driven-oci-setup-core-environment.md
+++ b/AppDev/cloud-native/scripted-setup/script-driven-oci-setup-core-environment.md
@@ -26,9 +26,9 @@ User information captured (initials and user identity) Entries for `USER_INITIAL
 
 <details><summary><b>User information or initials missing ?</b></summary>
 
-Can setup the user initials using the `$HOME/helidon-kubernetes/setup/common/initials-step.sh` script
+Can setup the user initials using the `$HOME/helidon-kubernetes/setup/common/initials-setup.sh` script
 
-Can setup the user ocid using the `$HOME/helidon-kubernetes/setup/common/user-identity-step.sh` script
+Can setup the user ocid using the `$HOME/helidon-kubernetes/setup/common/user-identity-setup.sh` script
 
 </details>
 
@@ -36,7 +36,7 @@ Compartment created - Entry for `COMPARTMENT_OCID`  in `$HOME/hk8sLabsSettings`
 
 <details><summary><b>Compartment info missing ?</b></summary>
 
-Can setup the compartment (or re-use and existing one) using the `$HOME/helidon-kubernetes/setup/common/compartment-step.sh` script
+Can setup the compartment (or re-use and existing one) using the `$HOME/helidon-kubernetes/setup/common/compartment-setup.sh` script
 
 </details>
 
@@ -44,7 +44,7 @@ Database created - Entry for `ATPDB_OCID`  in `$HOME/hk8sLabsSettings` and `$HOM
 
 <details><summary><b>Database info missing ?</b></summary>
 
-Can setup the database (or re-use and existing one) using the `$HOME/helidon-kubernetes/setup/common/database-step.sh` script
+Can setup the database (or re-use and existing one) using the `$HOME/helidon-kubernetes/setup/common/database-setup.sh` script
 
 </details>
 ---
@@ -218,7 +218,7 @@ Assuming you have `step` you can easily create the self signed root certificate
 
   1. Open the OCI Cloud shell and type
     
-  - `./step certificate create root.cluster.local root.crt root.key --profile root-ca --no-password --insecure`
+  - `$HOME/keys/step certificate create root.cluster.local $HOME/keys/root.crt $HOME/keys/root.key --kty=RSA --profile root-ca --no-password --insecure`
   
   ```
   Your certificate has been saved in root.crt.


### PR DESCRIPTION
when creating a cert now uses RSA, not EC as the key type in the example instructions